### PR TITLE
Issue #14: Use state_set() instead of config_set() for votingapi_last_cron

### DIFF
--- a/config/votingapi.settings.json
+++ b/config/votingapi.settings.json
@@ -1,6 +1,5 @@
 {
   "_config_name": "votingapi.settings",
-  "votingapi_last_cron": 0,
   "votingapi_anonymous_window": 86400,
   "votingapi_user_window": -1,
   "votingapi_calculation_schedule": "immediate",

--- a/votingapi.install
+++ b/votingapi.install
@@ -190,3 +190,17 @@ function votingapi_update_1202() {
     }
   }
 }
+
+/* Implements hook_update_N().
+ *
+ * Move votingapi_last_cron from config to state.
+ */
+function votingapi_update_1203() {
+  $config = config('votingapi.settings');
+  $last_cron = $config->get('votingapi_last_cron');
+  if ($last_cron !== NULL) {
+    state_set('votingapi_last_cron', $last_cron);
+    $config->clear('votingapi_last_cron');
+    $config->save();
+  }
+}

--- a/votingapi.module
+++ b/votingapi.module
@@ -107,13 +107,13 @@ function votingapi_views_api() {
 function votingapi_cron() {
   if (config_get('votingapi.settings', 'votingapi_calculation_schedule') == 'cron') {
     $time = REQUEST_TIME;
-    $last_cron = config_get('votingapi.settings', 'votingapi_last_cron');
+    $last_cron = state_get('votingapi_last_cron', 0);
     $result = db_query('SELECT DISTINCT entity_type, entity_id FROM {votingapi_vote} WHERE timestamp > :timestamp', array(':timestamp' => $last_cron));
     foreach ($result as $content) {
       votingapi_recalculate_results($content->entity_type, $content->entity_id, TRUE);
     }
 
-    config_set('votingapi.settings', 'votingapi_last_cron', $time);
+    state_set('votingapi_last_cron', $time);
   }
 
   _votingapi_cron_delete_orphaned();


### PR DESCRIPTION
Fixes #14.

`votingapi_last_cron` is environment-specific runtime state, not a configuration setting. Using `config_set()` fails on sites with read-only config directories (e.g., Pantheon in git mode with `ConfigFileStorage`).

Switches to `state_get()`/`state_set()` per [Backdrop's State API documentation](https://docs.backdropcms.org/change-records/statekey-value-storage-system-implemented), which lists `cron_last` as an explicit example of a state variable.